### PR TITLE
Refactor JWT refreshing to run inside an interceptor. No need to call…

### DIFF
--- a/src/main/java/no/ndla/taxonomy/Importer.java
+++ b/src/main/java/no/ndla/taxonomy/Importer.java
@@ -36,8 +36,6 @@ public class Importer {
     }
 
     void doImport(Entity entity) {
-        restClient.updateHeaders();
-
         if (entity == null) return;
 
         if (entity.type.equals(SUBJECT_TYPE)) {

--- a/src/test/java/no/ndla/taxonomy/ImportAuthTest.java
+++ b/src/test/java/no/ndla/taxonomy/ImportAuthTest.java
@@ -1,6 +1,7 @@
 package no.ndla.taxonomy;
 
 import no.ndla.taxonomy.client.Authentication;
+import no.ndla.taxonomy.client.HeaderRequestInterceptor;
 import no.ndla.taxonomy.client.TaxonomyRestClient;
 import no.ndla.taxonomy.client.TokenUpdateCheck;
 import org.junit.Test;
@@ -10,52 +11,81 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.*;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestTemplate;
 
 
+import java.io.IOException;
 import java.time.Instant;
+import java.util.List;
 
 import static no.ndla.taxonomy.TestUtils.*;
 import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ImportAuthTest {
-
-
-    @Mock
-    RestTemplate mockRestTemplate = Mockito.mock(RestTemplate.class);
-
-    @InjectMocks
-    TaxonomyRestClient restClient = new TaxonomyRestClient(BASE_URL, "NOT_ITEST", CLIENT_SECRET, TOKEN_SERVER, mockRestTemplate);
-
     @Test
     public void works_with_authentication() {
+        (new Runnable() {
+            private ClientHttpRequestInterceptor theLambdaInterceptor;
 
-        ResponseEntity<Authentication> response = Mockito.mock(ResponseEntity.class);
-        Authentication authentication = new Authentication();
-        authentication.expires_in = 1800l;
-        authentication.access_token = "test123";
-        authentication.scope = "test";
-        authentication.token_type = "test";
+            @Override
+            public void run() {
+                RestTemplate mockRestTemplate = mock(RestTemplate.class);
 
-        when(response.getBody()).thenReturn(authentication);
-        when(mockRestTemplate.exchange(
-                anyString(),
-                eq(HttpMethod.POST),
-                any(),
-                eq(Authentication.class))
-        ).thenReturn(response);
+                doAnswer(inv -> {
+                    List<ClientHttpRequestInterceptor> interceptors = inv.getArgumentAt(0, List.class);
+                    theLambdaInterceptor = interceptors.stream()
+                            .filter(interc -> !(interc instanceof HeaderRequestInterceptor))
+                            .reduce((a, b) -> {throw new RuntimeException("Single interceptor match expected!");})
+                            .orElseThrow(() -> new NullPointerException("Expected one single match"));
 
-        assertNull(restClient.last_token_update);
+                    return null;
+                }).when(mockRestTemplate).setInterceptors(any(List.class));
 
-        restClient.updateHeaders();
+                TaxonomyRestClient restClient = new TaxonomyRestClient(BASE_URL, "NOT_ITEST", CLIENT_SECRET, TOKEN_SERVER, mockRestTemplate);
 
-        assertNotNull(restClient.last_token_update);
+                assertNotNull(theLambdaInterceptor);
 
+                ResponseEntity<Authentication> response = mock(ResponseEntity.class);
+                Authentication authentication = new Authentication();
+                authentication.expires_in = 1800l;
+                authentication.access_token = "test123";
+                authentication.scope = "test";
+                authentication.token_type = "test";
+
+                when(response.getBody()).thenReturn(authentication);
+                when(mockRestTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(),
+                        eq(Authentication.class))
+                ).thenReturn(response);
+
+                assertNull(restClient.last_token_update);
+
+                try {
+                    HttpHeaders headers = new HttpHeaders();
+                    HttpRequest request = mock(HttpRequest.class);
+                    given(request.getHeaders()).willReturn(headers);
+                    ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+
+                    theLambdaInterceptor.intercept(request, null, execution);
+
+                    assertEquals("Bearer test123", headers.get("Authorization").stream().reduce((a, b) -> {throw new RuntimeException("Single result expected");}).orElse(null));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+                assertNotNull(restClient.last_token_update);
+            }
+        }).run();
     }
 
     @Test


### PR DESCRIPTION
… an update token method before doing anything that requires authorization anymore.